### PR TITLE
Remove double export default statements

### DIFF
--- a/002 - Basics of Redux Thunk/src/components/app.js
+++ b/002 - Basics of Redux Thunk/src/components/app.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 
-export default class App extends Component {
+class App extends Component {
   componentWillMount() {
     this.props.fetchUsers();
   }


### PR DESCRIPTION
Double export default statements causing build error at runtime for redux-thunk demo. 